### PR TITLE
Check for promise.then instead of using instanceof

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ function withAsync(fns) {
       invariant(isFunction(callback), `${name} must be provided a function!`);
       return (fns[name])(...args, done => {
         const promise = this::callback();
-        invariant(promise instanceof Promise, `${name} must return a promise!`);
+        invariant(promise && isFunction(promise.then), `${name} must return a promise!`);
         promise.then(done, done.fail);
       });
     };


### PR DESCRIPTION
When using polyfills for Promise, different polyfills have different implementations of Promise. An `instanceof` check can lead to unexpected results.

Fixes https://github.com/rdy/jasmine-async-suite/issues/2
